### PR TITLE
fix tool id

### DIFF
--- a/workflow.py
+++ b/workflow.py
@@ -239,6 +239,7 @@ class ConciergeAgent(Workflow):
                 chat_message=ChatMessage(
                     role="tool",
                     content=ev.response or self.default_tool_reject_str,
+                    additional_kwargs={"tool_call_id": ev.tool_id},
                 )
             )
 


### PR DESCRIPTION
It was causing an error with OpenAI API:

```
Error code: 400 - {'error': {'message': "Missing parameter 'tool_call_id': messages with role 'tool' must have a 'tool_call_id'.", 'type': 'invalid_request_error', 'param': 'messages.[15].tool_call_id', 'code': None}}
```